### PR TITLE
Support ESPHome name-based web entity IDs in Fang UI

### DIFF
--- a/webserver/packages/neato/COMPATIBILITY.md
+++ b/webserver/packages/neato/COMPATIBILITY.md
@@ -1,0 +1,41 @@
+# ESPHome web entity ID compatibility
+
+Fang's UI uses legacy keys such as `sensor-fuel_percent`. ESPHome 2026.8.2
+was observed sending `sensor/Fuel Percent` in its web server event stream.
+
+`src/entity-api.ts` normalizes name-based IDs into the keys expected by the
+existing UI and preserves the exact name in `api_id`. HTTP paths encode that
+name as a single URL segment. Older object-ID events retain their original
+IDs and endpoints. This targets the primary-device entities used by Fang;
+it does not add ESPHome sub-device support or change Fang's entity enums.
+
+Both initial detail events and later partial updates are normalized. When a
+partial event arrives first, the detail request uses the original API name,
+and its response is normalized before registration. Shared controls and table
+controls use the same path helper. Action names and query strings are not
+encoded together with the entity segment.
+
+From `webserver`, using Node 18 or newer for the built-in test runner:
+
+```sh
+npm ci
+npm test --workspace=@esphome-webserver/neato
+npm run build
+```
+
+The tests execute the source TypeScript with the existing TypeScript dependency,
+stub browser presentation dependencies, and capture requests without contacting
+a robot. They cover old/new IDs, punctuation, updates, fallback detail requests,
+and both action callers. Browser rendering and real robot actions require a
+separate hardware check; a successful build alone does not establish those.
+At the reviewed upstream revision, `npm ci` reports a missing
+`rollup-plugin-gzip` lockfile entry. On a Windows network share, npm workspace
+symlink creation can also fail. The isolated package can be validated without
+changing the lockfile:
+
+```sh
+cd webserver/packages/neato
+npm install --workspaces=false --package-lock=false --no-audit --no-fund
+npm test --workspaces=false
+npm run build --workspaces=false
+```

--- a/webserver/packages/neato/package.json
+++ b/webserver/packages/neato/package.json
@@ -3,6 +3,7 @@
   "version": "3.0.0",
   "scripts": {
     "start": "npm run dev",
+    "test": "node --test tests/entity-api.test.cjs",
     "dev": "vite",
     "xbuild": "vite build --emptyOutDir",
     "build": "vite build --emptyOutDir",

--- a/webserver/packages/neato/src/api.ts
+++ b/webserver/packages/neato/src/api.ts
@@ -1,3 +1,4 @@
+import { entityPath } from "./entity-api";
 import { entityConfig } from "./types";
 import { getBasePath } from "./utils";
 
@@ -5,7 +6,7 @@ window.apiBasePath = getBasePath();
 
 
 export function restAction(entity: entityConfig, action: string) {
-    fetch(`${window.apiBasePath}/${entity.domain}/${entity.id}/${action}`, {
+    fetch(`${window.apiBasePath}/${entityPath(entity)}/${action}`, {
         method: "POST",
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded'

--- a/webserver/packages/neato/src/custom-table.ts
+++ b/webserver/packages/neato/src/custom-table.ts
@@ -1,3 +1,4 @@
+import { entityPath } from "./entity-api";
 import { html, css, LitElement, nothing } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import cssReset from "./css/reset";
@@ -102,7 +103,7 @@ export class CustomTable extends LitElement implements RestAction {
   }
 
   restAction(entity: entityConfig, action: string) {
-    fetch(`${window.apiBasePath}/${entity.domain}/${entity.id}/${action}`, {
+    fetch(`${window.apiBasePath}/${entityPath(entity)}/${action}`, {
       method: "POST",
       headers:{
         'Content-Type': 'application/x-www-form-urlencoded'

--- a/webserver/packages/neato/src/entity-api.ts
+++ b/webserver/packages/neato/src/entity-api.ts
@@ -1,0 +1,18 @@
+/** Keep Fang's legacy UI keys separate from ESPHome's HTTP entity names. */
+export function normalizeEntity<T extends { id: string; api_id?: string }>(data: T): T {
+  const slash = data.id.indexOf("/");
+  if (slash < 0) return data;
+
+  const domain = data.id.slice(0, slash);
+  const name = data.id.slice(slash + 1);
+  return {
+    ...data,
+    id: `${domain}-${name.toLowerCase().replace(/[^a-z0-9_]/g, "_")}`,
+    api_id: name,
+  };
+}
+
+/** Encode the entity segment only: action/query strings are built by callers. */
+export function entityPath(entity: { domain: string; id: string; api_id?: string }): string {
+  return `${entity.domain}/${encodeURIComponent(entity.api_id ?? entity.id)}`;
+}

--- a/webserver/packages/neato/src/esp-app.ts
+++ b/webserver/packages/neato/src/esp-app.ts
@@ -1,3 +1,4 @@
+import { normalizeEntity, entityPath } from "./entity-api";
 import { LitElement, html, css, PropertyValues, nothing } from "lit";
 import { customElement, state, query } from "lit/decorators.js";
 
@@ -26,7 +27,7 @@ const _unknown_state_events: { [key: string]: number } = {};
 
 window.source?.addEventListener('state', (e: Event) => {
   const messageEvent = e as MessageEvent;
-  const data = JSON.parse(messageEvent.data.replace(/[\u0000-\u001F\u007F-\u009F]/g, ""));
+  const data = normalizeEntity(JSON.parse(messageEvent.data.replace(/[\u0000-\u001F\u007F-\u009F]/g, "")));
   let idx = window.entities.findIndex((x) => x.unique_id === data.id);
   if (idx != -1 && data.id) {
     if (typeof data.value === 'number') {
@@ -59,7 +60,7 @@ window.source?.addEventListener('state', (e: Event) => {
       let domain = parts[0];
       let id = parts.slice(1).join('-');
 
-      fetch(`${window.apiBasePath}/${domain}/${id}?detail=all`, {
+      fetch(`${window.apiBasePath}/${entityPath({ domain, id, api_id: data.api_id })}?detail=all`, {
         method: 'GET',
       })
         .then((r) => {
@@ -82,6 +83,7 @@ window.source?.addEventListener('state', (e: Event) => {
 
 
 function addEntity(data: any) {
+  data = normalizeEntity(data);
   console.log(data);
   let idx = window.entities.findIndex((x) => x.unique_id === data.id);
   if (idx === -1 && data.id) {

--- a/webserver/packages/neato/src/types.d.ts
+++ b/webserver/packages/neato/src/types.d.ts
@@ -13,6 +13,8 @@ export interface entityConfig {
   sorting_group?: string;
   domain: string;
   id: string;
+  /** Exact name used by name-based ESPHome HTTP endpoints. */
+  api_id?: string;
   state: string;
   detail: string;
   value: string;

--- a/webserver/packages/neato/tests/entity-api.test.cjs
+++ b/webserver/packages/neato/tests/entity-api.test.cjs
@@ -1,0 +1,119 @@
+const assert = require('node:assert/strict');
+const { test } = require('node:test');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const ts = require('typescript');
+
+// Execute the actual TypeScript modules with browser/visual dependencies stubbed.
+// No device or network access: all HTTP requests are captured below.
+function harness() {
+  const requests = [], listeners = {}, published = [];
+  const window = { location: { pathname: '/proxy/' }, apiBasePath: '/proxy', entities: [] };
+  let detail = { id: 'sensor/Fuel Percent', name: 'Fuel Percent', value: 97 };
+  const fetch = (url, options) => {
+    requests.push({ url, options });
+    return Promise.resolve({ ok: true, json: () => Promise.resolve(detail) });
+  };
+  const noopDecorator = () => () => {};
+  const stub = {
+    LitElement: class {}, html: () => '', css: () => '', nothing: undefined,
+    customElement: () => target => target, property: noopDecorator,
+    state: noopDecorator, query: noopDecorator,
+    getBasePath: () => '/proxy', ActionRenderer: class {},
+    entityStore: { set: entity => published.push(entity) },
+  };
+  const cache = {};
+  function load(name) {
+    if (cache[name]) return cache[name];
+    const filename = path.join(__dirname, '../src', name + '.ts');
+    // Match Vite's build-time substitution; the UI class is not instantiated here.
+    const source = fs.readFileSync(filename, 'utf8')
+      .replace(/import\.meta\.env\.PACKAGE_VERSION/g, JSON.stringify('test'));
+    const js = ts.transpileModule(source, { compilerOptions: {
+      module: ts.ModuleKind.CommonJS, target: ts.ScriptTarget.ES2020,
+      experimentalDecorators: true,
+    } }).outputText;
+    const exports = {};
+    const context = { exports, window, fetch, console: { log() {}, error() {} },
+      EventSource: class { addEventListener(type, fn) { listeners[type] = fn; } },
+      require: id => id === './entity-api' ? load('entity-api') : stub,
+    };
+    vm.runInNewContext(js, context, { filename });
+    cache[name] = exports;
+    return exports;
+  }
+  return { load, requests, listeners, window, published,
+    setDetail: value => { detail = value; },
+    emit: value => listeners.state({ data: JSON.stringify(value) }),
+  };
+}
+
+test('legacy IDs remain unchanged, including hyphens', () => {
+  const { normalizeEntity, entityPath } = harness().load('entity-api');
+  const input = { id: 'sensor-fuel-percent', value: 97 };
+  assert.equal(normalizeEntity(input), input);
+  assert.equal(entityPath({ domain: 'sensor', id: 'fuel-percent' }), 'sensor/fuel-percent');
+});
+
+test('new IDs retain exact API names and do not mutate input', () => {
+  const { normalizeEntity, entityPath } = harness().load('entity-api');
+  const input = { id: 'button/Spot Clean (Height & Width)', state: 'test' };
+  const result = normalizeEntity(input);
+  assert.equal(result.id, 'button-spot_clean__height___width_');
+  assert.equal(result.api_id, 'Spot Clean (Height & Width)');
+  assert.equal(input.id, 'button/Spot Clean (Height & Width)');
+  assert.equal(normalizeEntity(result), result);
+  assert.equal(entityPath({ domain: 'button', id: 'unused', api_id: 'A/B? #%' }),
+    'button/A%2FB%3F%20%23%25');
+});
+
+test('detail events and subsequent partial updates share one UI entity', () => {
+  const h = harness(); h.load('esp-app');
+  h.emit({ id: 'sensor/Fuel Percent', domain: 'sensor', name: 'Fuel Percent', value: 95 });
+  h.emit({ id: 'sensor/Fuel Percent', value: 97 });
+  assert.equal(h.window.entities.length, 1);
+  const entity = h.window.entities[0];
+  assert.equal(entity.unique_id, 'sensor-fuel_percent');
+  assert.equal(entity.id, 'fuel_percent');
+  assert.equal(entity.api_id, 'Fuel Percent');
+  assert.equal(entity.value, 97);
+  assert.equal(h.published.length, 1);
+  assert.equal(h.requests.length, 0);
+});
+
+test('partial event fetches exact encoded name and normalizes detail response', async () => {
+  const h = harness(); h.load('esp-app');
+  h.emit({ id: 'sensor/Fuel Percent', value: 97 });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(h.requests[0].url, '/proxy/sensor/Fuel%20Percent?detail=all');
+  assert.equal(h.requests[0].options.method, 'GET');
+  assert.equal(h.window.entities[0].unique_id, 'sensor-fuel_percent');
+  assert.equal(h.window.entities[0].api_id, 'Fuel Percent');
+});
+
+test('legacy partial events still use legacy detail endpoints', async () => {
+  const h = harness(); h.load('esp-app');
+  h.setDetail({ id: 'sensor-fuel_percent', name: 'Fuel Percent', value: 97 });
+  h.emit({ id: 'sensor-fuel_percent', value: 97 });
+  await new Promise(resolve => setImmediate(resolve));
+  assert.equal(h.requests[0].url, '/proxy/sensor/fuel_percent?detail=all');
+  assert.equal(h.window.entities[0].unique_id, 'sensor-fuel_percent');
+});
+
+test('shared actions encode entity names without encoding the action query', () => {
+  const h = harness(), api = h.load('api');
+  api.setText({ domain: 'text', id: 'timezone', api_id: 'Timezone' }, 'America/Los_Angeles');
+  assert.equal(h.requests[0].url, '/proxy/text/Timezone/set?value=America%2FLos_Angeles');
+  assert.equal(h.requests[0].options.method, 'POST');
+  api.pressButton({ domain: 'button', id: 'house_clean' });
+  assert.equal(h.requests[1].url, '/proxy/button/house_clean/press');
+});
+
+test('table actions use the same encoded path as shared actions', () => {
+  const h = harness(), { CustomTable } = h.load('custom-table');
+  CustomTable.prototype.restAction.call({},
+    { domain: 'button', id: 'send_to_start', api_id: 'Send to start' }, 'press');
+  assert.equal(h.requests[0].url, '/proxy/button/Send%20to%20start/press');
+  assert.equal(h.requests[0].options.method, 'POST');
+});


### PR DESCRIPTION
With ESPHome 2026.8.2, Fang's web UI remains on `loading...` because events contain IDs such as `sensor/Fuel Percent`, while the UI looks up `sensor-fuel_percent`. HTTP controls also need to use the exact entity name rather than the legacy object ID.

Normalize name-based IDs at the state/detail ingestion boundary and retain the original name in `api_id`. A shared path helper URL-encodes only the entity segment for fallback detail requests and both action callers. Legacy event IDs and endpoints remain supported. This keeps the existing primary-device UI keys; it does not add sub-device support or change entity enums.

Validation:

- Seven passing regression tests execute the source handlers with mocked browser dependencies and captured HTTP requests: legacy/new IDs, punctuation, partial updates, detail fallback, and both action callers.
- Vite production build passed (41 modules transformed).
- `git diff --check` passed; patch applicability checked against the recorded clean base.
- A corresponding earlier bundled workaround was installed on ESP32-C3 / Neato Connected Gen 2 firmware 2.2.0. Live robot data and the served adapter were verified. The user confirmed that the locally patched web page renders correctly. This source revision has not been flashed; physical control operation remains unconfirmed.

Validation environment: Node 24.16.0, npm on Windows. Upstream `npm ci` failed because the lockfile lacks a `rollup-plugin-gzip` entry. Dependencies were installed in the individual package using `--workspaces=false --package-lock=false`; the lockfile is unchanged. Reproduction commands and compatibility scope are documented in `webserver/packages/neato/COMPATIBILITY.md`.
