### PR TITLE
Expose Gen 2 motor telemetry for home automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Since there is a couple of robots from Neato and they have different firmware ve
 - ³ - Support can be added by version 2
 
 Please refer to the [status.md](./status.md) for project status, roadmap and version meanings!
+
+Gen 2 exposes [motor telemetry for home automation](./gen2-motor-telemetry.md), including running/moving/stationary activity and guidance on combining stopped motors with robot errors when inferring a cleaning cycle.
   
 The ability to create, view and edit floormaps so the robot can get the same functionallity with no-go lines and zones is in the making.
 

--- a/config/comp/gen2.yaml
+++ b/config/comp/gen2.yaml
@@ -1,6 +1,7 @@
 substitutions:
   version: "1.2.1"
   type: "gen2"
+  motor_timeout: 10s # Must exceed infointerval; missing samples are not stationary.
   buildinfo: "${version} [TX:${uart_tx} RX:${uart_rx}]"
 
 
@@ -62,6 +63,26 @@ esphome:
 
 
 script:
+  # Valid motor samples restart the watchdog, even if the ESP stays connected
+  # to Home Assistant while the robot stops replying over UART.
+  - id: expire_motor_telemetry
+    mode: restart
+    then:
+      - delay: ${motor_timeout}
+      - script.execute: invalidate_motor_telemetry
+
+  - id: invalidate_motor_telemetry
+    then:
+      - lambda: |-
+          id(motorVacuumRPM).publish_state(NAN);
+          id(motorBrushRPM).publish_state(NAN);
+          id(motorLeftWheelRPM).publish_state(NAN);
+          id(motorRightWheelRPM).publish_state(NAN);
+          id(vacuumMotorRunning).invalidate_state();
+          id(brushRunning).invalidate_state();
+          id(wheelsMoving).invalidate_state();
+          id(motorActivity).publish_state("unavailable");
+
   - id: get_user_settings
     mode: queued
     then:
@@ -71,8 +92,10 @@ script:
   - id: get_all_data
     mode: queued
     then: 
-      - uart.write: "GetErr \n"  
-      - delay: 50ms  
+      - uart.write: "GetErr \n"
+      - delay: 150ms
+      - uart.write: "GetMotors \n"
+      - delay: 150ms
       - uart.write: "GetCharger \n"    
       - delay: 50ms  
       - uart.write: "GetUserSettings \n"  
@@ -145,6 +168,8 @@ interval:
   - interval: ${infointerval}
     then:
       - uart.write: "GetErr \n"
+      - delay: 150ms
+      - uart.write: "GetMotors \n"
   - interval: ${chargerinterval}
     then: 
       - uart.write: "GetCharger \n"
@@ -233,6 +258,66 @@ uart:
                 id(uiState).publish_state("Started, ready for commands!");
                 id(initial_data_get).execute();
             }
+          }
+
+          else if (command == "GetMotors") {
+            // BEGIN motor decoder (exercised by tests/test_gen2_motors.py)
+            struct Sample {
+              float vacuum = NAN, brush = NAN, left = NAN, right = NAN;
+              bool valid = false;
+              bool vacuum_running() const { return valid && std::fabs(vacuum) > 0; }
+              bool brush_running() const { return valid && std::fabs(brush) > 0; }
+              bool wheels_moving() const { return valid && (std::fabs(left) > 0 || std::fabs(right) > 0); }
+              const char *activity() const {
+                if (!valid) return "unavailable";
+                if (vacuum_running() || brush_running()) return "cleaning";
+                return wheels_moving() ? "moving" : "stationary";
+              }
+            };
+            auto parse_motors = [](const std::vector<std::string> &lines) {
+              Sample result;
+              bool seen[4] = {};
+              for (const auto &line : lines) {
+                const auto comma = line.find(',');
+                if (comma == std::string::npos) continue;
+                auto key = line.substr(0, comma);
+                const auto first = key.find_first_not_of(" \t\r\n");
+                if (first == std::string::npos) continue;
+                key = key.substr(first, key.find_last_not_of(" \t\r\n") - first + 1);
+                int index = key == "Vacuum_RPM" ? 0 : key == "Brush_RPM" ? 1 : key == "LeftWheel_RPM" ? 2 : key == "RightWheel_RPM" ? 3 : -1;
+                if (index < 0) continue;
+                if (seen[index]) return Sample{}; // Ambiguous/mixed frames are not stationary samples.
+                const auto value = line.substr(comma + 1);
+                char *end = nullptr;
+                const float rpm = std::strtof(value.c_str(), &end);
+                if (end == value.c_str() || !std::isfinite(rpm)) return Sample{};
+                while (*end && std::isspace(static_cast<unsigned char>(*end))) ++end;
+                if (*end) return Sample{};
+                seen[index] = true;
+                if (index == 0) result.vacuum = rpm;
+                else if (index == 1) result.brush = rpm;
+                else if (index == 2) result.left = rpm;
+                else result.right = rpm;
+              }
+              result.valid = seen[0] && seen[1] && seen[2] && seen[3];
+              return result;
+            };
+            // END motor decoder
+            const auto sample = parse_motors(lines);
+            if (!sample.valid) {
+              id(expire_motor_telemetry).stop();
+              id(invalidate_motor_telemetry).execute();
+              return;
+            }
+            id(motorVacuumRPM).publish_state(sample.vacuum);
+            id(motorBrushRPM).publish_state(sample.brush);
+            id(motorLeftWheelRPM).publish_state(sample.left);
+            id(motorRightWheelRPM).publish_state(sample.right);
+            id(vacuumMotorRunning).publish_state(sample.vacuum_running());
+            id(brushRunning).publish_state(sample.brush_running());
+            id(wheelsMoving).publish_state(sample.wheels_moving());
+            id(motorActivity).publish_state(sample.activity());
+            id(expire_motor_telemetry).execute();
           }
 
           else if (command == "GetCharger") {
@@ -439,6 +524,35 @@ text:
 
 
 sensor:
+  - platform: template
+    id: motorVacuumRPM
+    name: "Vacuum Motor RPM"
+    unit_of_measurement: "rpm"
+    accuracy_decimals: 0
+    icon: mdi:fan
+    update_interval: never
+  - platform: template
+    id: motorBrushRPM
+    name: "Brush RPM"
+    unit_of_measurement: "rpm"
+    accuracy_decimals: 0
+    icon: mdi:rotate-right
+    update_interval: never
+  - platform: template
+    id: motorLeftWheelRPM
+    name: "Left Wheel RPM"
+    unit_of_measurement: "rpm"
+    accuracy_decimals: 0
+    icon: mdi:wheel
+    update_interval: never
+  - platform: template
+    id: motorRightWheelRPM
+    name: "Right Wheel RPM"
+    unit_of_measurement: "rpm"
+    accuracy_decimals: 0
+    icon: mdi:wheel
+    update_interval: never
+
   # --- GetCharger ---
   - platform: template
     id: chargerFuelPercent
@@ -477,6 +591,17 @@ sensor:
 
 
 binary_sensor:
+  - platform: template
+    id: vacuumMotorRunning
+    name: "Vacuum Motor Running"
+  - platform: template
+    id: brushRunning
+    name: "Brush Running"
+  - platform: template
+    id: wheelsMoving
+    name: "Wheels Moving"
+    device_class: moving
+
   # --- GetCharger ---
   - platform: template
     id: chargerBatteryOverTemp
@@ -525,6 +650,12 @@ binary_sensor:
 
 
 text_sensor:
+  - platform: template
+    id: motorActivity
+    name: "Motor Activity"
+    icon: mdi:robot-vacuum
+    update_interval: never
+
   - platform: template
     id: nbs_time_text
     name: "NBS Time"

--- a/gen2-motor-telemetry.md
+++ b/gen2-motor-telemetry.md
@@ -1,0 +1,47 @@
+# Gen 2 motor telemetry for home automation
+
+The Gen 2 package exposes motor readings so Home Assistant and other automation platforms can observe cleaning activity and infer cleaning cycles. It does not implement a cleaning-cycle state machine or send notifications.
+
+## Entities
+
+| Entity name | Value |
+| --- | --- |
+| Vacuum Motor RPM | Vacuum motor speed |
+| Brush RPM | Main brush speed |
+| Left Wheel RPM | Left wheel speed; signed values accepted |
+| Right Wheel RPM | Right wheel speed; signed values accepted |
+| Vacuum Motor Running | Absolute vacuum RPM greater than zero |
+| Brush Running | Absolute brush RPM greater than zero |
+| Wheels Moving | Either wheel has nonzero absolute RPM |
+| Motor Activity | `cleaning`, `moving`, `stationary`, or `unavailable` |
+
+`cleaning` means the vacuum or brush motor is running. `moving` means a wheel is running while both cleaning motors are stopped. `stationary` means all four reported RPMs are zero. These describe motor activity, not the robot's internal job state or proof of unobstructed travel.
+
+GetMotors is queried after GetErr, with a 150 ms delay, at the existing `infointerval` (normally two seconds). The initial/manual data refresh also requests motors. The existing charger polling interval is unchanged. Entity IDs in HA depend on the device name and any user renaming; use the IDs from your installation.
+
+All four RPM fields must be present and finite. A malformed/unsupported response invalidates the whole sample immediately. After a valid sample, no new valid sample for `motor_timeout` (default `10s`) invalidates all RPM/boolean values and sets Motor Activity to `unavailable`. Keep `motor_timeout` longer than `infointerval`; for example, use `motor_timeout: 30s` with a ten-second polling interval. Before the first valid sample the entities have no state. Missing data is never treated as stopped motors.
+
+## Detecting a cycle in an automation
+
+One useful step in detecting whether a cleaning cycle has ended is **checking Robot Error when the motors stop**:
+
+1. Observe actual vacuum/brush activity to establish that a run was in progress.
+2. Debounce a transition to all motors stopped; a short pause in wheel movement alone is not a stopped cleaning run.
+3. Check Robot Error. A reported error identifies a fault-related stop that should be handled separately from normal cycle completion.
+4. If no error is reported, combine that with dock/external-power state and your automation's prior activity/request history. Stopped motors plus no error alone can also mean a pause or idle state, so it is not a definitive finished signal.
+
+For example, previous cleaning activity followed by stopped motors, no reported error, and stable dock power is a useful return-to-dock inference. It can still represent a recharge before resuming rather than successful completion of the entire job. An unreported obstruction also cannot be ruled out solely because Robot Error says no errors. Treat unavailable telemetry as unknown, not stationary.
+
+This change leaves cycle interpretation, timing thresholds, notifications, and completion policies to the home automation system. It does not alter timezone controls, NBS Time, the scheduler, robot commands, or the UI State sensor.
+
+## Validation
+
+The decoder tests compile and execute the actual C++ decoder extracted from `config/comp/gen2.yaml`, rather than a separate reimplementation. They require Python 3 and a C++17 compiler (`CXX` can override `c++`):
+
+```sh
+python3 tests/test_gen2_motors.py
+```
+
+The running fixture was captured from a Botvac Connected (non-DX, model 905-0249), robot firmware 2.2.0: vacuum 9000 RPM, brush 1362 RPM, left wheel 5100 RPM and right wheel 4500 RPM. A local version of the same telemetry logic on an ESP32-C3 Mini was also observed docked/charging with all four RPMs zero and no error. This is one hardware/firmware combination, not validation across every Gen 2 model. The focused PR configuration is compile-tested separately; full end-to-end cleaning-cycle automation remains the user's responsibility.
+
+Related work: [PR #71](https://github.com/vacuula/fang/pull/71) also proposes Gen 2 motor telemetry along with other changes. This contribution is independently scoped to the current modular Gen 2 package and includes complete-frame validation, unavailable handling, and decoder regression tests.

--- a/tests/fixtures/gen2-getmotors.txt
+++ b/tests/fixtures/gen2-getmotors.txt
@@ -1,0 +1,16 @@
+GetMotors
+Parameter,Value
+Brush_RPM,1362
+Brush_mA,233
+Vacuum_RPM,9000
+Vacuum_mA,1002
+LeftWheel_RPM,5100
+LeftWheel_Load%,100
+LeftWheel_PositionInMM,78039
+LeftWheel_Speed,290
+RightWheel_RPM,4500
+RightWheel_Load%,89
+RightWheel_PositionInMM,65667
+RightWheel_Speed,256
+ROTATION_SPEED,5.02
+SideBrush_mA,67

--- a/tests/test_gen2_motors.py
+++ b/tests/test_gen2_motors.py
@@ -1,0 +1,69 @@
+"""Compile and test the actual decoder embedded in the Gen 2 YAML (Python 3 + C++17)."""
+import json
+import os
+from pathlib import Path
+import re
+import shlex
+import subprocess
+import tempfile
+import textwrap
+
+ROOT = Path(__file__).resolve().parents[1]
+yaml_text = (ROOT / 'config/comp/gen2.yaml').read_text(encoding='utf-8')
+match = re.search(r'// BEGIN motor decoder[^\n]*\n(.*?)\s*// END motor decoder', yaml_text, re.S)
+if not match:
+    raise SystemExit('Motor decoder markers not found')
+decoder = textwrap.dedent(match.group(1))
+fixture = (ROOT / 'tests/fixtures/gen2-getmotors.txt').read_text(encoding='utf-8').splitlines()
+fixture_cpp = ','.join(json.dumps(line) for line in fixture)
+source = r'''
+#include <cassert>
+#include <cctype>
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
+int main() {
+''' + decoder + '\n auto sample = parse_motors({' + fixture_cpp + r'''});
+  assert(sample.valid && sample.vacuum == 9000 && sample.brush == 1362);
+  assert(sample.left == 5100 && sample.right == 4500);
+  assert(sample.vacuum_running() && sample.brush_running() && sample.wheels_moving());
+  assert(std::string(sample.activity()) == "cleaning");
+  sample = parse_motors({"Vacuum_RPM,9000", "Brush_RPM,0", "LeftWheel_RPM,0", "RightWheel_RPM,0"});
+  assert(!sample.wheels_moving() && std::string(sample.activity()) == "cleaning");
+  sample = parse_motors({"Vacuum_RPM,0", "Brush_RPM,1362", "LeftWheel_RPM,0", "RightWheel_RPM,0"});
+  assert(sample.brush_running() && std::string(sample.activity()) == "cleaning");
+  sample = parse_motors({"Vacuum_RPM,0", "Brush_RPM,0", "LeftWheel_RPM,-150", "RightWheel_RPM,0"});
+  assert(sample.wheels_moving() && std::string(sample.activity()) == "moving");
+  sample = parse_motors({"Vacuum_RPM,0", "Brush_RPM,0", "LeftWheel_RPM,0", "RightWheel_RPM,-150"});
+  assert(sample.wheels_moving() && std::string(sample.activity()) == "moving");
+  sample = parse_motors({" Vacuum_RPM , 0 ", "Brush_RPM,0", "LeftWheel_RPM,0", "RightWheel_RPM,0"});
+  assert(sample.valid && !sample.vacuum_running() && !sample.brush_running() && !sample.wheels_moving());
+  assert(std::string(sample.activity()) == "stationary");
+  for (const auto &bad : {"", "bad", "NaN", "inf", "-inf", "1e100", "100junk", "0,0"}) {
+    sample = parse_motors({std::string("Vacuum_RPM,") + bad, "Brush_RPM,0", "LeftWheel_RPM,0", "RightWheel_RPM,0"});
+    assert(!sample.valid && std::string(sample.activity()) == "unavailable");
+  }
+  assert(!parse_motors({"Vacuum_RPM,0", "Brush_RPM,0", "LeftWheel_RPM,0"}).valid);
+  assert(!parse_motors({"Unknown Cmd: 'GetMotors'"}).valid);
+  assert(!parse_motors({}).valid);
+  assert(!parse_motors({"Vacuum_RPM,0", "Vacuum_RPM,1", "Brush_RPM,0", "LeftWheel_RPM,0", "RightWheel_RPM,0"}).valid);
+  // Invalid values in every field must invalidate the entire frame.
+  for (int field = 0; field < 4; ++field) {
+    std::vector<std::string> rows = {"Vacuum_RPM,0", "Brush_RPM,0", "LeftWheel_RPM,0", "RightWheel_RPM,0"};
+    rows[field] = rows[field].substr(0, rows[field].find(',') + 1) + "bad";
+    assert(!parse_motors(rows).valid);
+  }
+  // A valid stopped sample after a malformed frame can recover normally.
+  assert(std::string(parse_motors({"Vacuum_RPM,0", "Brush_RPM,0", "LeftWheel_RPM,0", "RightWheel_RPM,0"}).activity()) == "stationary");
+  std::cout << "PASS: captured running frame, brush/vacuum activity, signed wheels, stationary, whitespace, malformed/missing/duplicate fields and recovery\n";
+}
+'''
+with tempfile.TemporaryDirectory(prefix='fang-gen2-motors-') as directory:
+    directory = Path(directory)
+    cpp = directory / 'test.cpp'
+    binary = directory / ('test.exe' if os.name == 'nt' else 'test')
+    cpp.write_text(source, encoding='utf-8')
+    subprocess.run(shlex.split(os.environ.get('CXX', 'c++')) + ['-std=c++17', '-Wall', '-Wextra', '-Werror', str(cpp), '-o', str(binary)], check=True)
+    subprocess.run([str(binary)], check=True)


### PR DESCRIPTION
Gen 2 currently exposes dock/error telemetry but does not publish motor activity for automations. This adds GetMotors polling and eight entities to the existing modular Gen 2 package: vacuum, brush and both wheel RPMs; vacuum/brush running and wheels-moving flags; and a combined Motor Activity sensor.

Motor Activity reports `cleaning` when the vacuum or brush runs, `moving` when only wheels run, and `stationary` when all four RPMs are zero. All four fields must parse successfully. Malformed or unsupported responses invalidate the sample immediately; a restartable watchdog marks readings unavailable after `motor_timeout` (default 10 seconds) without a valid frame.

These sensors let Home Assistant and other automation platforms infer cleaning cycles. **One useful step is to check Robot Error when the motors stop:** an error indicates a fault-related stop, while no error can help identify a possible normal cycle end when combined with previous activity and dock state. No error alone does not distinguish a pause from a finished job, and docking can also be a recharge before resuming. Cycle policy, debounce timing and notifications remain in the user's automation.

The change preserves NBS Time, timezone controls, scheduling, charger polling cadence, robot controls, web UI and existing HA templates. It includes documentation and tests that extract and execute the actual decoder from the YAML.

Validation:
- `python3 tests/test_gen2_motors.py`: captured running frame, vacuum/brush-only activity, signed wheel RPMs, stationary readings, whitespace, malformed/missing/duplicate fields and recovery.
- ESPHome 2026.8.2: ESP32-C3 firmware compilation with the HA package, plus no-HA package configuration validation.
- Hardware evidence: GetMotors captured on a Botvac Connected 905-0249, firmware 2.2.0, with vacuum 9000 RPM, brush 1362 RPM and both wheels moving. A locally installed version of the same decoder also reported all motors stopped while docked/charging. The exact PR configuration is compile-tested, not flashed, and this does not claim validation across all Gen 2 models.

Related: #71 also proposes Gen 2 motor telemetry alongside other changes. This is a focused contribution against the current `config/comp/gen2.yaml` layout, with complete-frame validation, unavailable handling and decoder regression tests.